### PR TITLE
Replace uint with unsigned int and remove trailing spaces

### DIFF
--- a/Params.h
+++ b/Params.h
@@ -50,7 +50,7 @@ public:
      * The order of the group
      */
     Bignum groupOrder;
-    
+
     IMPLEMENT_SERIALIZE
     (
         READWRITE(initialized);
@@ -58,7 +58,7 @@ public:
         READWRITE(h);
         READWRITE(modulus);
         READWRITE(groupOrder);
-    )    
+    )
 };
 
 class AccumulatorAndProofParams {
@@ -108,7 +108,7 @@ public:
      * Required by the accumulator proof.
      */
     Bignum maxCoinValue;
-    
+
     /**
      * The second of two groups used to form a commitment to
      * a coin (which it self is a commitment to a serial number).
@@ -127,13 +127,13 @@ public:
      * Security parameter.
      * Bit length of the challenges used in the accumulator proof.
      */
-    uint k_prime;
+    unsigned int k_prime;
 
     /**
      * Security parameter.
      * The statistical zero-knowledgeness of the accumulator proof.
      */
-    uint k_dprime;
+    unsigned int k_dprime;
 
     IMPLEMENT_SERIALIZE
     (
@@ -167,7 +167,7 @@ public:
     * compromised. The integer "N" must be a MINIMUM of 1024
     * in length. 3072 bits is strongly recommended.
     **/
-    Params(Bignum accumulatorModulus, 
+    Params(Bignum accumulatorModulus,
            uint32_t securityLevel = ZEROCOIN_DEFAULT_SECURITYLEVEL);
 
     bool initialized;
@@ -192,13 +192,13 @@ public:
      * The number of iterations to use in the serial
      * number proof.
      */
-    uint zkp_iterations;
+    unsigned int zkp_iterations;
 
     /**
      * The amount of the hash function we use for
      * proofs.
      */
-    uint zkp_hash_len;
+    unsigned int zkp_hash_len;
 
    IMPLEMENT_SERIALIZE
    (

--- a/SerialNumberSignatureOfKnowledge.cpp
+++ b/SerialNumberSignatureOfKnowledge.cpp
@@ -28,7 +28,7 @@ SerialNumberSignatureOfKnowledge::SerialNumberSignatureOfKnowledge(const
     if (params->coinCommitmentGroup.modulus != params->serialNumberSoKCommitmentGroup.groupOrder) {
         throw ZerocoinException("Groups are not structured correctly.");
     }
-    
+
 	Bignum a = params->coinCommitmentGroup.g;
 	Bignum b = params->coinCommitmentGroup.h;
 	Bignum g = params->serialNumberSoKCommitmentGroup.g;
@@ -73,7 +73,7 @@ SerialNumberSignatureOfKnowledge::SerialNumberSignatureOfKnowledge(const
 #ifdef ZEROCOIN_THREADING
 	#pragma omp parallel for
 #endif
-	for(uint i = 0; i < params->zkp_iterations; i++) {
+	for(unsigned int i = 0; i < params->zkp_iterations; i++) {
 		int bit = i % 8;
 		int byte = i / 8;
 
@@ -117,7 +117,7 @@ bool SerialNumberSignatureOfKnowledge::Verify(const Bignum& coinSerialNumber, co
 #ifdef ZEROCOIN_THREADING
 	#pragma omp parallel for
 #endif
-	for(uint i = 0; i < params->zkp_iterations; i++){
+	for(unsigned int i = 0; i < params->zkp_iterations; i++){
 		int bit = i % 8;
 		int byte = i / 8;
 		bool challenge_bit = ((hashbytes[byte] >> bit) & 0x01);
@@ -130,7 +130,7 @@ bool SerialNumberSignatureOfKnowledge::Verify(const Bignum& coinSerialNumber, co
 							params->serialNumberSoKCommitmentGroup.modulus;
 		}
 	}
-	for(uint i = 0; i < params->zkp_iterations; i++){
+	for(unsigned int i = 0; i < params->zkp_iterations; i++){
 		hasher << tprime[i];
 	}
 	return hasher.GetHash() == hash;

--- a/bitcoin_bignum/bignum.h
+++ b/bitcoin_bignum/bignum.h
@@ -119,14 +119,14 @@ public:
     * @param k The bit length of the number.
     * @return
     */
-    static CBigNum RandKBitBigum(const uint k){
+    static CBigNum RandKBitBigum(const unsigned int k){
     	CBigNum ret;
 		if(!BN_rand(&ret, k, -1, 0)){
 			throw bignum_error("CBigNum:rand element : BN_rand failed");
 		}
 		return ret;
     }
-    
+
     /**Returns the size in bits of the underlying bignum.
      *
      * @return the size
@@ -169,7 +169,7 @@ public:
 
         if (sn < (int64)0)
         {
-            // Since the minimum signed integer cannot be represented as positive so long as its type is signed, 
+            // Since the minimum signed integer cannot be represented as positive so long as its type is signed,
             // and it's not well-defined what happens if you make it unsigned before negating it,
             // we instead increment the negative integer by 1, convert it, then increment the (now positive) unsigned integer by 1 to compensate
             n = -(sn + 1);
@@ -415,7 +415,7 @@ public:
     	CBigNum ret;
         if (!BN_mod_mul(&ret, this, &b, &m, pctx))
     			throw bignum_error("CBigNum::mul_mod : BN_mod_mul failed");
-        
+
     	return ret;
     }
 
@@ -453,7 +453,7 @@ public:
    			throw bignum_error("CBigNum::inverse*= :BN_mod_inverse");
    		return ret;
     }
-    
+
     /**
      * Generates a random (safe) prime of numBits bits
      * @param numBits the number of bits
@@ -466,7 +466,7 @@ public:
    			throw bignum_error("CBigNum::generatePrime*= :BN_generate_prime_ex");
    		return ret;
     }
-    
+
     /**
      * Calculates the greatest common divisor (GCD) of two numbers.
      * @param m the second element
@@ -494,11 +494,11 @@ public:
        	}
        	return ret;
     }
-    
+
     bool isOne() const {
         return BN_is_one(this);
     }
-    
+
     bool operator!() const
     {
         return BN_is_zero(this);


### PR DESCRIPTION
MinGW doesn't include the non-standard data type uint, see http://sourceforge.net/p/mingw/bugs/1381/

I replaced uint with unsigned and also deleted trailing spaces in the affected files.
