### PR TITLE
Created CMake based build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ tutorial
 *.vrb
 *.xdy
 *.tdo
+
+*~
+/build

--- a/CMake/Modules/BoostConfig.cmake
+++ b/CMake/Modules/BoostConfig.cmake
@@ -1,0 +1,27 @@
+# Copyright 2013 Corgan Labs
+# This file is part of the Zerocoin project
+# See LICENSE file or http://opensource.org/licenses/MIT for terms
+
+if(DEFINED __INCLUDED_BOOSTCONFIG_CMAKE)
+    return()
+endif()
+
+set(__INCLUDED_BOOSTCONFIG_CMAKE TRUE)
+
+set(BOOST_REQUIRED_COMPONENTS
+  system
+)
+
+find_package(Boost "1.48" COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+
+set(Boost_ADDITIONAL_VERSIONS
+  "1.45.0" "1.45" "1.46.0" "1.46" "1.47.0" "1.47" "1.48.0" "1.48" "1.49.0" "1.49"
+  "1.50.0" "1.50" "1.51.0" "1.51" "1.52.0" "1.52" "1.53.0" "1.53" "1.54.0" "1.54"
+  "1.55.0" "1.55" "1.56.0" "1.56" "1.57.0" "1.57" "1.58.0" "1.58" "1.59.0" "1.59"
+  "1.60.0" "1.60" "1.61.0" "1.61" "1.62.0" "1.62" "1.63.0" "1.63" "1.64.0" "1.64"
+  "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
+)
+
+list(APPEND Boost_LIBRARIES
+  ${Boost_SYSTEM_LIBRARY}
+)

--- a/CMake/cmake_uninstall.cmake.in
+++ b/CMake/cmake_uninstall.cmake.in
@@ -1,0 +1,34 @@
+# Copyright 2013 Kitware, Inc.
+# http://www.vtk.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F
+# http://creativecommons.org/licenses/by/2.5/
+
+IF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  MESSAGE(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
+ENDIF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+FILE(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+STRING(REGEX REPLACE "\n" ";" files "${files}")
+FOREACH(file ${files})
+  MESSAGE(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
+  IF(EXISTS "$ENV{DESTDIR}${file}")
+    EXEC_PROGRAM(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    IF(NOT "${rm_retval}" STREQUAL 0)
+      MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+    ENDIF(NOT "${rm_retval}" STREQUAL 0)
+  ELSEIF(IS_SYMLINK "$ENV{DESTDIR}${file}")
+    EXEC_PROGRAM(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    IF(NOT "${rm_retval}" STREQUAL 0)
+      MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+    ENDIF(NOT "${rm_retval}" STREQUAL 0)
+  ELSE(EXISTS "$ENV{DESTDIR}${file}")
+    MESSAGE(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
+  ENDIF(EXISTS "$ENV{DESTDIR}${file}")
+ENDFOREACH(file)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,104 @@
+# Copyright 2013 Corgan Labs
+# This file is part of the Zerocoin project
+# See LICENSE file or http://opensource.org/licenses/MIT for terms
+
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+    message(FATAL_ERROR "Prevented in-tree build. This is bad practice.")
+endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+
+#
+# Setup overall project
+#
+cmake_minimum_required(VERSION 2.8)
+project(zerocoin)
+
+# Appended to CMAKE_INSTALL_PREFIX
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/Modules)
+
+#
+# Project-wide package dependencies
+#
+# Find and configure the Boost C++ libraries
+include(BoostConfig)
+
+# Find and configure OpenSSL crypto library
+include(FindOpenSSL)
+
+#
+# Project-wide directory settings
+#
+set(BITCOIN_BIGNUM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/bitcoin_bignum)
+
+#
+# Project-wide installation settings
+#
+set(ZEROCOIN_INCLUDE_DIR include)
+set(ZEROCOIN_BIN_DIR     bin)
+set(ZEROCOIN_LIB_DIR     lib)
+
+#
+# Add individual directories to project
+#
+#add_subdirectory(foo)
+
+#
+# Create uninstall target
+#
+configure_file(
+  ${CMAKE_SOURCE_DIR}/CMake/cmake_uninstall.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+@ONLY)
+
+add_custom_target(uninstall
+  ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+)
+
+########################################################################
+# Shared library generation libzerocoin.so
+########################################################################
+
+include_directories(
+  ${BITCOIN_BIGNUM_INCLUDE_DIR}
+  ${Boost_INCLUDE_DIRS}
+  ${OPENSSL_INCLUDE_DIR}
+)
+
+link_directories(
+  ${Boost_LIBRARY_DIRS}
+)
+
+list(APPEND zerocoin_libs
+  ${Boost_LIBRARIES}
+  ${OPENSSL_CRYPTO_LIBRARY}
+)
+
+list(APPEND zerocoin_sources
+  Accumulator.cpp
+  AccumulatorProofOfKnowledge.cpp
+  Coin.cpp
+  CoinSpend.cpp
+  Commitment.cpp
+  ParamGeneration.cpp
+  Params.cpp
+  SerialNumberSignatureOfKnowledge.cpp
+  SpendMetaData.cpp
+)
+
+add_library(zerocoin SHARED ${zerocoin_sources})
+target_link_libraries(zerocoin ${zerocoin_libs})
+
+########################################################################
+# Executable files
+########################################################################
+
+add_executable(paramgen paramgen.cpp)
+target_link_libraries(paramgen zerocoin)
+
+add_executable(benchmark Benchmark.cpp)
+target_link_libraries(benchmark zerocoin)
+
+add_executable(test Tests.cpp)
+target_link_libraries(test zerocoin)
+
+add_executable(tutorial Tutorial.cpp)
+target_link_libraries(tutorial zerocoin)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
- Adds CMakeLists.txt and support files
- Tests for installation of Boost and OpenSSL
- Adds LICENSE file

This does not yet create 'make install/uninstall' targets.  There are a few other niceties (like a package config file) that can be added to make this easier for 3rd party developers to compile against.
