### PR TITLE
Hashing of sg, sh, g_n and g_h not necessary

### DIFF
--- a/AccumulatorProofOfKnowledge.cpp
+++ b/AccumulatorProofOfKnowledge.cpp
@@ -20,18 +20,18 @@ AccumulatorProofOfKnowledge::AccumulatorProofOfKnowledge(const AccumulatorAndPro
         const Commitment& commitmentToCoin, const AccumulatorWitness& witness,
         Accumulator& a): params(p) {
 
-	Bignum sg = params->accumulatorPoKCommitmentGroup.g;
-	Bignum sh = params->accumulatorPoKCommitmentGroup.h;
+	const Bignum sg = params->accumulatorPoKCommitmentGroup.g;
+	const Bignum sh = params->accumulatorPoKCommitmentGroup.h;
 
-	Bignum g_n = params->accumulatorQRNCommitmentGroup.g;
-	Bignum h_n = params->accumulatorQRNCommitmentGroup.h;
+	const Bignum g_n = params->accumulatorQRNCommitmentGroup.g;
+	const Bignum h_n = params->accumulatorQRNCommitmentGroup.h;
 
-	Bignum e = commitmentToCoin.getContents();
-	Bignum r = commitmentToCoin.getRandomness();
+	const Bignum e = commitmentToCoin.getContents();
+	const Bignum r = commitmentToCoin.getRandomness();
 
-	Bignum r_1 = Bignum::randBignum(params->accumulatorModulus/4);
-	Bignum r_2 = Bignum::randBignum(params->accumulatorModulus/4);
-	Bignum r_3 = Bignum::randBignum(params->accumulatorModulus/4);
+	const Bignum r_1 = Bignum::randBignum(params->accumulatorModulus/4);
+	const Bignum r_2 = Bignum::randBignum(params->accumulatorModulus/4);
+	const Bignum r_3 = Bignum::randBignum(params->accumulatorModulus/4);
 
 	this->C_e = g_n.pow_mod(e, params->accumulatorModulus) * h_n.pow_mod(r_1, params->accumulatorModulus);
 	this->C_u = witness.getValue() * h_n.pow_mod(r_2, params->accumulatorModulus);
@@ -42,11 +42,11 @@ AccumulatorProofOfKnowledge::AccumulatorProofOfKnowledge(const AccumulatorAndPro
 		r_alpha = 0-r_alpha;
 	}
 
-	Bignum r_gamma = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
-	Bignum r_phi = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
-	Bignum r_psi = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
-	Bignum r_sigma = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
-	Bignum r_xi = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
+	const Bignum r_gamma = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
+	const Bignum r_phi = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
+	const Bignum r_psi = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
+	const Bignum r_sigma = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
+	const Bignum r_xi = Bignum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
 
 	Bignum r_epsilon =  Bignum::randBignum((params->accumulatorModulus/4) * Bignum(2).pow(params->k_prime + params->k_dprime));
 	if(!(Bignum::randBignum(Bignum(3)) % 2)) {
@@ -80,10 +80,10 @@ AccumulatorProofOfKnowledge::AccumulatorProofOfKnowledge(const AccumulatorAndPro
 	this->t_4 = (C_r.pow_mod(r_alpha, params->accumulatorModulus) * ((h_n.inverse(params->accumulatorModulus)).pow_mod(r_delta, params->accumulatorModulus)) * ((g_n.inverse(params->accumulatorModulus)).pow_mod(r_beta, params->accumulatorModulus))) % params->accumulatorModulus;
 
 	CHashWriter hasher(0,0);
-	hasher << *params << sg << sh << g_n << h_n << commitmentToCoin.getCommitmentValue() << C_e << C_u << C_r << st_1 << st_2 << st_3 << t_1 << t_2 << t_3 << t_4;
+	hasher << *params << commitmentToCoin.getCommitmentValue() << C_e << C_u << C_r << st_1 << st_2 << st_3 << t_1 << t_2 << t_3 << t_4;
 
 	//According to the proof, this hash should be of length k_prime bits.  It is currently greater than that, which should not be a problem, but we should check this.
-	Bignum c = Bignum(hasher.GetHash());
+	const Bignum c = Bignum(hasher.GetHash());
 
 	this->s_alpha = r_alpha - c*e;
 	this->s_beta = r_beta - c*r_2*e;
@@ -101,43 +101,39 @@ AccumulatorProofOfKnowledge::AccumulatorProofOfKnowledge(const AccumulatorAndPro
 /** Verifies that a commitment c is accumulated in accumulator a
  */
 bool AccumulatorProofOfKnowledge:: Verify(const Accumulator& a, const Bignum& valueOfCommitmentToCoin) const {
-	Bignum sg = params->accumulatorPoKCommitmentGroup.g;
-	Bignum sh = params->accumulatorPoKCommitmentGroup.h;
+	const Bignum sg = params->accumulatorPoKCommitmentGroup.g;
+	const Bignum sh = params->accumulatorPoKCommitmentGroup.h;
 
-	Bignum g_n = params->accumulatorQRNCommitmentGroup.g;
-	Bignum h_n = params->accumulatorQRNCommitmentGroup.h;
+	const Bignum g_n = params->accumulatorQRNCommitmentGroup.g;
+	const Bignum h_n = params->accumulatorQRNCommitmentGroup.h;
 
 	//According to the proof, this hash should be of length k_prime bits.  It is currently greater than that, which should not be a problem, but we should check this.
 	CHashWriter hasher(0,0);
-	hasher << *params << sg << sh << g_n << h_n << valueOfCommitmentToCoin << C_e << C_u << C_r << st_1 << st_2 << st_3 << t_1 << t_2 << t_3 << t_4;
+	hasher << *params << valueOfCommitmentToCoin << C_e << C_u << C_r << st_1 << st_2 << st_3 << t_1 << t_2 << t_3 << t_4;
 
-	Bignum c = Bignum(hasher.GetHash()); //this hash should be of length k_prime bits
+	const Bignum c = Bignum(hasher.GetHash()); //this hash should be of length k_prime bits
 
-	Bignum st_1_prime = (valueOfCommitmentToCoin.pow_mod(c, params->accumulatorPoKCommitmentGroup.modulus) * sg.pow_mod(s_alpha, params->accumulatorPoKCommitmentGroup.modulus) * sh.pow_mod(s_phi, params->accumulatorPoKCommitmentGroup.modulus)) % params->accumulatorPoKCommitmentGroup.modulus;
-	Bignum st_2_prime = (sg.pow_mod(c, params->accumulatorPoKCommitmentGroup.modulus) * ((valueOfCommitmentToCoin * sg.inverse(params->accumulatorPoKCommitmentGroup.modulus)).pow_mod(s_gamma, params->accumulatorPoKCommitmentGroup.modulus)) * sh.pow_mod(s_psi, params->accumulatorPoKCommitmentGroup.modulus)) % params->accumulatorPoKCommitmentGroup.modulus;
-	Bignum st_3_prime = (sg.pow_mod(c, params->accumulatorPoKCommitmentGroup.modulus) * (sg * valueOfCommitmentToCoin).pow_mod(s_sigma, params->accumulatorPoKCommitmentGroup.modulus) * sh.pow_mod(s_xi, params->accumulatorPoKCommitmentGroup.modulus)) % params->accumulatorPoKCommitmentGroup.modulus;
+	const Bignum st_1_prime = (valueOfCommitmentToCoin.pow_mod(c, params->accumulatorPoKCommitmentGroup.modulus) * sg.pow_mod(s_alpha, params->accumulatorPoKCommitmentGroup.modulus) * sh.pow_mod(s_phi, params->accumulatorPoKCommitmentGroup.modulus)) % params->accumulatorPoKCommitmentGroup.modulus;
+	const Bignum st_2_prime = (sg.pow_mod(c, params->accumulatorPoKCommitmentGroup.modulus) * ((valueOfCommitmentToCoin * sg.inverse(params->accumulatorPoKCommitmentGroup.modulus)).pow_mod(s_gamma, params->accumulatorPoKCommitmentGroup.modulus)) * sh.pow_mod(s_psi, params->accumulatorPoKCommitmentGroup.modulus)) % params->accumulatorPoKCommitmentGroup.modulus;
+	const Bignum st_3_prime = (sg.pow_mod(c, params->accumulatorPoKCommitmentGroup.modulus) * (sg * valueOfCommitmentToCoin).pow_mod(s_sigma, params->accumulatorPoKCommitmentGroup.modulus) * sh.pow_mod(s_xi, params->accumulatorPoKCommitmentGroup.modulus)) % params->accumulatorPoKCommitmentGroup.modulus;
 
-	Bignum t_1_prime = (C_r.pow_mod(c, params->accumulatorModulus) * h_n.pow_mod(s_zeta, params->accumulatorModulus) * g_n.pow_mod(s_epsilon, params->accumulatorModulus)) % params->accumulatorModulus;
-	Bignum t_2_prime = (C_e.pow_mod(c, params->accumulatorModulus) * h_n.pow_mod(s_eta, params->accumulatorModulus) * g_n.pow_mod(s_alpha, params->accumulatorModulus)) % params->accumulatorModulus;
-	Bignum t_3_prime = ((a.getValue()).pow_mod(c, params->accumulatorModulus) * C_u.pow_mod(s_alpha, params->accumulatorModulus) * ((h_n.inverse(params->accumulatorModulus)).pow_mod(s_beta, params->accumulatorModulus))) % params->accumulatorModulus;
-	Bignum t_4_prime = (C_r.pow_mod(s_alpha, params->accumulatorModulus) * ((h_n.inverse(params->accumulatorModulus)).pow_mod(s_delta, params->accumulatorModulus)) * ((g_n.inverse(params->accumulatorModulus)).pow_mod(s_beta, params->accumulatorModulus))) % params->accumulatorModulus;
+	const Bignum t_1_prime = (C_r.pow_mod(c, params->accumulatorModulus) * h_n.pow_mod(s_zeta, params->accumulatorModulus) * g_n.pow_mod(s_epsilon, params->accumulatorModulus)) % params->accumulatorModulus;
+	const Bignum t_2_prime = (C_e.pow_mod(c, params->accumulatorModulus) * h_n.pow_mod(s_eta, params->accumulatorModulus) * g_n.pow_mod(s_alpha, params->accumulatorModulus)) % params->accumulatorModulus;
+	const Bignum t_3_prime = ((a.getValue()).pow_mod(c, params->accumulatorModulus) * C_u.pow_mod(s_alpha, params->accumulatorModulus) * ((h_n.inverse(params->accumulatorModulus)).pow_mod(s_beta, params->accumulatorModulus))) % params->accumulatorModulus;
+	const Bignum t_4_prime = (C_r.pow_mod(s_alpha, params->accumulatorModulus) * ((h_n.inverse(params->accumulatorModulus)).pow_mod(s_delta, params->accumulatorModulus)) * ((g_n.inverse(params->accumulatorModulus)).pow_mod(s_beta, params->accumulatorModulus))) % params->accumulatorModulus;
 
-	bool result = false;
+	const bool result_st1 = (st_1 == st_1_prime);
+	const bool result_st2 = (st_2 == st_2_prime);
+	const bool result_st3 = (st_3 == st_3_prime);
 
-	bool result_st1 = (st_1 == st_1_prime);
-	bool result_st2 = (st_2 == st_2_prime);
-	bool result_st3 = (st_3 == st_3_prime);
+	const bool result_t1 = (t_1 == t_1_prime);
+	const bool result_t2 = (t_2 == t_2_prime);
+	const bool result_t3 = (t_3 == t_3_prime);
+	const bool result_t4 = (t_4 == t_4_prime);
 
-	bool result_t1 = (t_1 == t_1_prime);
-	bool result_t2 = (t_2 == t_2_prime);
-	bool result_t3 = (t_3 == t_3_prime);
-	bool result_t4 = (t_4 == t_4_prime);
+	const bool result_range = ((s_alpha >= -(params->maxCoinValue * Bignum(2).pow(params->k_prime + params->k_dprime + 1))) && (s_alpha <= (params->maxCoinValue * Bignum(2).pow(params->k_prime + params->k_dprime + 1))));
 
-	bool result_range = ((s_alpha >= -(params->maxCoinValue * Bignum(2).pow(params->k_prime + params->k_dprime + 1))) && (s_alpha <= (params->maxCoinValue * Bignum(2).pow(params->k_prime + params->k_dprime + 1))));
-
-	result = result_st1 && result_st2 && result_st3 && result_t1 && result_t2 && result_t3 && result_t4 && result_range;
-
-	return result;
+	return result_st1 && result_st2 && result_st3 && result_t1 && result_t2 && result_t3 && result_t4 && result_range;
 }
 
 } /* namespace libzerocoin */

--- a/AccumulatorProofOfKnowledge.h
+++ b/AccumulatorProofOfKnowledge.h
@@ -58,7 +58,7 @@ public:
 	    READWRITE(s_psi);
 	)
 private:
-	const AccumulatorAndProofParams* params;
+	const AccumulatorAndProofParams* const params;
 
 	/* Return values for proof */
 	Bignum C_e;


### PR DESCRIPTION
I'm not 100% sure, but isn't the hashing of sg, sh, g_h and g_h redundant since they are also part of *params?

I've also added const to some values in the proof (makes it a little bit clearer IMHO).

I also noticed that

```
bool result = false;
```

isn't needed and it's possible to directly return with the result.
