### PR TITLE
Bug fix? I think the generators g and h for the QR_N commitment group should have different values

### DIFF
--- a/ParamGeneration.cpp
+++ b/ParamGeneration.cpp
@@ -86,7 +86,7 @@ CalculateParams(Params &params, Bignum N, string aux, uint32_t securityLevel)
 	        calculateSeed(N, aux, securityLevel, STRING_QRNCOMMIT_GROUPG),
 	        &resultCtr).pow_mod(Bignum(2), N);
 	params.accumulatorParams.accumulatorQRNCommitmentGroup.h = generateIntegerFromSeed(NLen - 1,
-	        calculateSeed(N, aux, securityLevel, STRING_QRNCOMMIT_GROUPG),
+	        calculateSeed(N, aux, securityLevel, STRING_QRNCOMMIT_GROUPH),
 	        &resultCtr).pow_mod(Bignum(2), N);
 
 	// Calculate the accumulator base, which we calculate as "u = C**2 mod N"


### PR DESCRIPTION
It looks like one of the authors duplicated code and failed to change all "g" to "h" in the duplicate.

Before this fix, g and h would always be set to the same value; I am a novice at crypto so I cannot tell if this could lead to de-anonymization, coin forgery, or both.
