### PR TITLE
Patch serial # exploit.

### DIFF
--- a/CoinSpend.cpp
+++ b/CoinSpend.cpp
@@ -29,6 +29,11 @@ CoinSpend::CoinSpend(const Params* p, const PrivateCoin& coin,
 		throw ZerocoinException("Accumulator witness does not verify");
 	}
 
+	// The serial # needs to be within the specified range our else it can be incremented by the modulus and create another valid proof
+	if (!HasValidSerial()) {
+		throw ZerocoinException("Invalid serial # range");
+	}
+
 	// 1: Generate two separate commitments to the public coin (C), each under
 	// a different set of public parameters. We do this because the RSA accumulator
 	// has specific requirements for the commitment parameters that are not
@@ -77,6 +82,11 @@ const uint256 CoinSpend::signatureHash(const SpendMetaData &m) const {
 	CHashWriter h(0,0);
 	h << m << serialCommitmentToCoinValue << accCommitmentToCoinValue << commitmentPoK << accumulatorPoK;
 	return h.GetHash();
+}
+
+bool CoinSpend::HasValidSerial() const
+{
+	return coinSerialNumber > 0 && coinSerialNumber < params->coinCommitmentGroup.groupOrder;
 }
 
 } /* namespace libzerocoin */

--- a/CoinSpend.h
+++ b/CoinSpend.h
@@ -76,6 +76,7 @@ public:
 	 */
 	const CoinDenomination getDenomination();
 
+	bool HasValidSerial() const;
 	bool Verify(const Accumulator& a, const SpendMetaData &metaData) const;
 
 	IMPLEMENT_SERIALIZE


### PR DESCRIPTION
The serial # range needs to be checked or else the serial number is able to be incremented to a value that will create a valid proof, thus allowing multiple spends of a single mint.