### PR TITLE
Add tx metadata to SoK challenge hash.

### DIFF
--- a/SerialNumberSignatureOfKnowledge.cpp
+++ b/SerialNumberSignatureOfKnowledge.cpp
@@ -35,7 +35,7 @@ SerialNumberSignatureOfKnowledge::SerialNumberSignatureOfKnowledge(const
 	Bignum h = params->serialNumberSoKCommitmentGroup.h;
 
 	CHashWriter hasher(0,0);
-	hasher << *params << commitmentToCoin.getCommitmentValue() << coin.getSerialNumber();
+	hasher << *params << commitmentToCoin.getCommitmentValue() << coin.getSerialNumber() << msghash;
 
 	vector<Bignum> r(params->zkp_iterations);
 	vector<Bignum> v(params->zkp_iterations);
@@ -110,7 +110,7 @@ bool SerialNumberSignatureOfKnowledge::Verify(const Bignum& coinSerialNumber, co
 	Bignum g = params->serialNumberSoKCommitmentGroup.g;
 	Bignum h = params->serialNumberSoKCommitmentGroup.h;
 	CHashWriter hasher(0,0);
-	hasher << *params << valueOfCommitmentToCoin <<coinSerialNumber;
+	hasher << *params << valueOfCommitmentToCoin << coinSerialNumber << msghash;
 
 	vector<CBigNum> tprime(params->zkp_iterations);
 	unsigned char *hashbytes = (unsigned char*) &this->hash;


### PR DESCRIPTION
Currently libzerocoin ignores the transaction meta data that is supposed to be added to the Signature of Knowledge. This leaves zerocoin spend transactions susceptible to middle man/malleability attacks.

Adding the transaction hash to the SoK hash that the SoK challenge is based on should help prevent malleability.